### PR TITLE
Fix health check test setup

### DIFF
--- a/src/health-check/health-check.service.spec.ts
+++ b/src/health-check/health-check.service.spec.ts
@@ -1,13 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { Logger } from '@nestjs/common';
 
 import { HealthCheckService } from './health-check.service';
 
 describe('HealthcheckService', () => {
   let service: HealthCheckService;
 
+  const dataSourceMock = {
+    query: jest.fn().mockResolvedValue([1]),
+  } as unknown as DataSource;
+
+  const loggerMock = {
+    log: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger;
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [HealthCheckService],
+      providers: [
+        HealthCheckService,
+        { provide: DataSource, useValue: dataSourceMock },
+        { provide: Logger, useValue: loggerMock },
+      ],
     }).compile();
 
     service = module.get<HealthCheckService>(HealthCheckService);
@@ -15,5 +30,12 @@ describe('HealthcheckService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('checks database connectivity', async () => {
+    await expect(service.checkDatabase()).resolves.toBe(
+      'Database connection is successful',
+    );
+    expect(dataSourceMock.query).toHaveBeenCalledWith('SELECT 1');
   });
 });


### PR DESCRIPTION
## Summary
- fix the HealthCheckService unit test by providing mock dependencies

## Testing
- `npm test` *(fails: Cannot resolve dependencies for many other specs)*

------
https://chatgpt.com/codex/tasks/task_e_6881c4b43584832884a61cf28cc20447