### PR TITLE
Fix typo in migration guide

### DIFF
--- a/docs/TYPEORM_MIGRATION_GUIDE.md
+++ b/docs/TYPEORM_MIGRATION_GUIDE.md
@@ -136,4 +136,4 @@ npm run typeorm migration:run
 | `npm run typeorm migration:generate migrations/{Name}`  | Create a new migration based on entity changes    |
 | `npm run typeorm migration:run` |  Apply all pending migrations    |
 | `npm run typeorm migration:revert`    | Revert the last migration    |
-| `npm run typeorm migration:show`    | Show miogration history    |
+| `npm run typeorm migration:show`    | Show migration history    |


### PR DESCRIPTION
## Summary
- fix typo in migration guide documentation

## Testing
- `npm test` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881c772771083289993c58aaabc6f2f