### PR TITLE
Fix async save in loan application history

### DIFF
--- a/src/loan-applications/loan-application-history/loan-application-history.service.ts
+++ b/src/loan-applications/loan-application-history/loan-application-history.service.ts
@@ -81,7 +81,7 @@ export class LoanApplicationHistoryService {
       changed_at: new Date(),
     });
 
-    this.historyRepo.save(record);
+    await this.historyRepo.save(record);
 
     this.eventBus.emit(
       'loan.status.changed',


### PR DESCRIPTION
## Summary
- ensure loan application history creation awaits the DB save

## Testing
- `npm test` *(fails: Nest can't resolve dependencies of several controllers and services)*

------
https://chatgpt.com/codex/tasks/task_e_6881c77f98c08328a615c423aee6ba40